### PR TITLE
Adaption to match new maploader feature WFS-downloader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Dependencies
 find_package(ament_cmake REQUIRED)
 find_package(adore_math REQUIRED)
+find_package(caches REQUIRED PATHS ${CMAKE_INSTALL_PREFIX}/../caches/lib/cmake/caches)
 find_package(adore_dynamics REQUIRED)
 find_package(adore_map_conversions REQUIRED)
 find_package(adore_math_conversions REQUIRED)


### PR DESCRIPTION
Slight adaption of CMakeLists.txt to match new maploader feature WFS-downloader (I added just one line).

This PR is related to [PR 5](https://github.com/eclipse-adore/adore_map/pull/5) of adore_map, and to [PR 83](https://github.com/eclipse-adore/adore/pull/83) of adore.

It must be merged before [PR 83](https://github.com/eclipse-adore/adore/pull/83) of adore can be merged successfully.