### PR TITLE
Removed find_package command for caches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Dependencies
 find_package(ament_cmake REQUIRED)
 find_package(adore_math REQUIRED)
-find_package(caches REQUIRED PATHS ${CMAKE_INSTALL_PREFIX}/../caches/lib/cmake/caches)
 find_package(adore_dynamics REQUIRED)
 find_package(adore_map_conversions REQUIRED)
 find_package(adore_math_conversions REQUIRED)


### PR DESCRIPTION
Removed find_package command for caches

This PR removes just one line from CMakeLists.txt (a find_package command for caches). 

It had been inserted as a workaround for a building issue. This has become obsolete by commit https://github.com/eclipse-adore/adore_map/commit/8d0b31adb5780a6cbf846d409444235c0584dfd3 by @akoerner1 (thanks!)